### PR TITLE
Using shorter export syntax in file index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,12 @@
-import {render} from './src/Render.js'
-import {default as Children} from './src/Children.js'
-import {fragment as Fragment} from './src/Enum.js'
-import {valid as isValidElement, clone as cloneElement} from './src/Element.js'
-import {create as createElement, create as h, portal as Portal} from './src/Element.js'
-import {memo} from './src/Component.js'
-import {lazy, suspense as Suspense} from './src/Suspense.js'
-import {context as Context} from './src/Context.js'
-import {boundary as Boundary} from './src/Exception.js'
-import {reference as useRef, memoize as useMemo, callback as useCallback} from './src/Hook.js'
-import {state as useState, reducer as useReducer, context as useContext, resource as useResource} from './src/Hook.js'
-import {effect as useEffect, layout as useLayout} from './src/Hook.js'
-
-export {render}
-export {memo, lazy, Suspense, Boundary, Context, Portal, Fragment, Children}
-export {h, createElement, cloneElement, isValidElement}
-export {useRef, useMemo, useCallback, useState, useReducer, useContext, useResource, useEffect, useLayout}
+export {render} from './src/Render.js'
+export {default as Children} from './src/Children.js'
+export {fragment as Fragment} from './src/Enum.js'
+export {valid as isValidElement, clone as cloneElement} from './src/Element.js'
+export {create as createElement, create as h, portal as Portal} from './src/Element.js'
+export {memo} from './src/Component.js'
+export {lazy, suspense as Suspense} from './src/Suspense.js'
+export {context as Context} from './src/Context.js'
+export {boundary as Boundary} from './src/Exception.js'
+export {reference as useRef, memoize as useMemo, callback as useCallback} from './src/Hook.js'
+export {state as useState, reducer as useReducer, context as useContext, resource as useResource} from './src/Hook.js'
+export {effect as useEffect, layout as useLayout} from './src/Hook.js'


### PR DESCRIPTION
Minor changes - just shorter export syntax, easier to read and maintain.