### PR TITLE
fix #106

### DIFF
--- a/server/src/Serialize.js
+++ b/server/src/Serialize.js
@@ -8,7 +8,12 @@ import * as Stringify from './Stringify.js'
  * @return {object}
  */
 export function render (element, target, callback) {
-	return Dyo.render(element, target, dispatch).then(callback)
+	return Dyo.render(element, target, function (target) {
+		dispatch.call(this, target)
+		if (callback) {
+			callback(target)
+		}
+	})
 }
 
 /**

--- a/src/Schedule.js
+++ b/src/Schedule.js
@@ -23,8 +23,10 @@ export var struct = Utility.extend(function fiber (element, target) {
 	 * @param {function?} value
 	 * @return {PromiseLike<object>}
 	 */
-	then: {value: function (value) {
-		return finalize(this, this.target, value), this
+	then: {value: function (success, failure) {
+		return (this.async || Promise.resolve(null)).then(() =>
+			new Promise((resolve) => finalize(this, this.target, resolve))
+		).then(success, failure)
 	}}
 })
 

--- a/test/Component.js
+++ b/test/Component.js
@@ -255,12 +255,12 @@ describe('Component', () => {
 		const stack = []
 		const Primary = props => props.children
 
-		render(h(Primary, {}, Promise.resolve('1')), target, (current) => {
-			return stack.push(0, current)
-		}).then((current) => {
-			return stack.push(1, current), new Promise((resolve) => setTimeout(() => resolve(stack.push(2)), 50))
-		}).then((current) => {
-			done(assert.deepEqual(stack, [0, current, 1, current, 2]))
+		render(h(Primary, {}, Promise.resolve('1')), target, () => {
+			return stack.push(0)
+		}).then(() => {
+			return stack.push(1), new Promise((resolve) => setTimeout(() => resolve(stack.push(2)), 50))
+		}).then(() => {
+			done(assert.deepEqual(stack, [0, 1, 2]))
 		})
 	})
 

--- a/test/Render.js
+++ b/test/Render.js
@@ -294,4 +294,12 @@ describe('Render', () => {
 			})
 		})
 	})
+
+	it('should propagate error to promise', (done) => {
+		render(h(Promise.reject(new Error('xxx'))), target)
+		.then((() => done(new Error('Expected failure'))), (err) => {
+			assert.equal(err.message, 'xxx')
+			done()
+		})
+	})
 })


### PR DESCRIPTION
Fixes the `then()` interface on `fiber` for errors and async correctness