### PR TITLE
component functions that return iterables are resolved asynchronously to their return value, fixes #113

### DIFF
--- a/src/Component.js
+++ b/src/Component.js
@@ -74,7 +74,7 @@ export function forward (value, callback, element, props) {
  * @return {object}
  */
 export function render (fiber, element, props) {
-	return fiber.owner = element, fiber.index = 0, Element.from(element.type(props), 0, props)
+	return fiber.owner = element, fiber.index = 0, Element.from(element.type(props), 0, props, element.type)
 }
 
 /**


### PR DESCRIPTION
See #113

```js
async function* useHook() {
  yield await Promise.resolve(null)
  useMemo(_=> 'x')
  return 'xxx'
}

function* Component() {
  var a = yield* useHook()
  return h('div', a) // <div>xxx</div>
} 

// await is no longer necessary
function* Component() {
  var a = yield Promise.resolve('xxx')
  return h('div', a) // <div>xxx</div>
} 
```

Non-components are not affected. e.g.

```js
h('div', new Set(['a', 'b', 'c'])) // <div>abc</div>
```

Missing tests